### PR TITLE
Updating package to resolve reported NPM package (high) vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "apigw-stage-environments",
       "version": "0.2.0",
       "dependencies": {
-        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.79.1-alpha.0",
-        "@aws-sdk/client-cognito-identity-provider": "^3.332.0",
-        "@aws-sdk/client-secrets-manager": "^3.332.0",
-        "aws-cdk-lib": "^2.79.1",
+        "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.83.1-alpha.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.352.0",
+        "@aws-sdk/client-secrets-manager": "^3.352.0",
+        "aws-cdk-lib": "^2.83.1",
         "axios": "^1.4.0",
-        "cdk-nag": "^2.27.8",
-        "constructs": "^10.2.24",
+        "cdk-nag": "^2.27.37",
+        "constructs": "^10.2.52",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -22,16 +22,16 @@
       },
       "devDependencies": {
         "@cucumber/cucumber": "^9.1.2",
-        "@types/aws-lambda": "^8.10.115",
-        "@types/jest": "^29.5.1",
-        "@types/node": "^18.15.11",
-        "@types/prettier": "2.7.2",
-        "aws-cdk": "^2.79.1",
+        "@types/aws-lambda": "^8.10.117",
+        "@types/jest": "^29.5.2",
+        "@types/node": "^20.3.1",
+        "@types/prettier": "^2.7.3",
+        "aws-cdk": "^2.83.1",
         "expect": "^29.5.0",
         "jest": "^29.5.0",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.4"
+        "typescript": "^5.1.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.168",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.168.tgz",
-      "integrity": "sha512-w0NQAhoeqqTwcf9HoO+NaSval1fGQcxByFg+z6sHT/gkpyrsnuR23dGRY4ARBUWL1DUyjWYptFe0CFyy1Vdmsg=="
+      "version": "2.2.190",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.190.tgz",
+      "integrity": "sha512-Q/PiNMbs073DO0Qg5d/cs/X2qZylqiuOwAfTRMUgOqNrUEIwPnAHQNtH0gmYWsCSKkttQG929WmBtivlK6NRhA=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -58,35 +58,50 @@
       "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.141",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.141.tgz",
-      "integrity": "sha512-+Yu9Ij3jrIoyuYlx71rfBMeiTmS3YCrhvhGKNLwYvOTrij5ZTO+b3FYlrN/J31Bx8tRQrDlR75ERbxt4Wb/v9A=="
+      "version": "2.0.164",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.164.tgz",
+      "integrity": "sha512-mqK5sGcnjTuPLdhvGqSueSObGFMszYsfe1wKFlbeaoJWG47ngO8AQXnM7CboPUpvCajcig3aITuKvuZ27+FM+Q=="
     },
     "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.79.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.79.1-alpha.0.tgz",
-      "integrity": "sha512-B5MDJjIa7DmykRxLYu1k2tnLNxllg4hwRWWgsMn+2xgXyZ0xmmdrxCXaAUx+SBiCxxpvumS3ukAGq7u5eYHvvA==",
+      "version": "2.83.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.83.1-alpha.0.tgz",
+      "integrity": "sha512-4pX4H3Ez4hCjPsJO4FMYtj561GyWQG058igNKAI6zCJlkz858T47YOCwRtDhwUg65D5hEiEB46wd/F8eGfosoA==",
       "peer": true,
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.79.1",
+        "aws-cdk-lib": "2.83.1",
         "constructs": "^10.0.0"
       }
     },
     "node_modules/@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
-      "version": "2.79.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.79.1-alpha.0.tgz",
-      "integrity": "sha512-H+fb2cP7Fs5tQMBww/hz4w+OKP4eELBB3uhgPUv7LE/frcnKfaoXum6tCj1xfb+SkaieiMbyxBx2JXAiUX/GGQ==",
+      "version": "2.83.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.83.1-alpha.0.tgz",
+      "integrity": "sha512-6568fNxpb2EWlwwuNbvRZyRzFB4GKDzaVl1uwZVtTB8aEEnf+M6KYyTL5ez4NRXlq+t8xUt8utMBANFY8ttJbg==",
       "engines": {
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
-        "@aws-cdk/aws-apigatewayv2-alpha": "2.79.1-alpha.0",
-        "aws-cdk-lib": "2.79.1",
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.83.1-alpha.0",
+        "aws-cdk-lib": "2.83.1",
         "constructs": "^10.0.0"
       }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -165,11 +180,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.329.0.tgz",
-      "integrity": "sha512-hzrjPNQcJoSPe0oS20V5i98oiEZSM3mKNiR6P3xHTHTPI/F23lyjGZ+/CSkCmJbSWfGZ5sHZZcU6AWuS7xBdTw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -177,44 +192,45 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.332.0.tgz",
-      "integrity": "sha512-uzVAfIFXnc+qDFCx1IehpRFVWVXleIogkmnKKS1gHS5LZ0Nr0b+QZmy/Ip6dfcG6UJ9P8eM5Or0R8HJk1NLwgA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.352.0.tgz",
+      "integrity": "sha512-FOc/vjUMHzMTp4Cc/oV6nKbtnJclS6IqWr1H4kNrjRQBdgrGJtb0YT8gLtyKF+J323QrTZVus31P/AkjfSmxgA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.332.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.332.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/client-sts": "3.352.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -222,44 +238,45 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.332.0.tgz",
-      "integrity": "sha512-xn8Ft+y+XggryvvPnKSEYhuidxWMMAXTfM4Dk1HAbzrpyAYRIuvYApt0a9nWa9DNM6Oi0yhcVvmsJW0/R+tvcA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.352.0.tgz",
+      "integrity": "sha512-P3RuTBlst0+/iKY3XcF3OxFy4k7zD/PYqLG2Gf02FED20EVrZIbc1ZJxSqP6+4tVZI6H3ql9eYyHPHJ60rMNrg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.332.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.332.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/client-sts": "3.352.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -268,41 +285,42 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.332.0.tgz",
-      "integrity": "sha512-4q1Nko8M6YVANdEiLYvdv1qb00j4xN4ppE/6d4xpGp7DxHYlm0GA762h0/TR2dun+2I+SMnwj4Fv6BxOmzBaEw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.352.0.tgz",
+      "integrity": "sha512-oeO36rvRvYbUlsgzYtLI2/BPwXdUK4KtYw+OFmirYeONUyX5uYx8kWXD66r3oXViIYMqhyHKN3fhkiFmFcVluQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -310,41 +328,42 @@
       }
     },
     "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.332.0.tgz",
-      "integrity": "sha512-tz8k8Yqm4TScIfit0Tum2zWAq1md+gZKr747CSixd4Zwcp7Vwh75cRoL7Rz1ZHSEn1Yo983MWREevVez3SubLw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.352.0.tgz",
+      "integrity": "sha512-PQdp0KOr478CaJNohASTgtt03W8Y/qINwsalLNguK01tWIGzellg2N3bA+IdyYXU8Oz3+Ab1oIJMKkUxtuNiGg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -352,45 +371,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.332.0.tgz",
-      "integrity": "sha512-uVobnXIzMcEhwBDyk6iOt36N/TRNI8hwq7MQugjYGj7Inma9g4vnR09hXJ24HxyKCoVUoIgMbEguQ43+/+uvDQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.352.0.tgz",
+      "integrity": "sha512-Lt7uSdwgOrwYx8S6Bhz76ewOeoJNFiPD+Q7v8S/mJK8T7HUE/houjomXC3UnFaJjcecjWv273zEqV67FgP5l5g==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.332.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-sdk-sts": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -398,13 +418,13 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.329.0.tgz",
-      "integrity": "sha512-Oj6eiT3q+Jn685yvUrfRi8PhB3fb81hasJqdrsEivA8IP8qAgnVUTJzXsh8O2UX8UM2MF6A1gTgToSgneJuw2Q==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -412,12 +432,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.329.0.tgz",
-      "integrity": "sha512-B4orC9hMt9hG82vAR0TAnQqjk6cFDbO2S14RdzUj2n2NPlGWW4Blkv3NTo86K0lq011VRhtqaLcuTwn5EJD5Sg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -425,14 +445,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.329.0.tgz",
-      "integrity": "sha512-ggPlnd7QROPTid0CwT01TYYGvstRRTpzTGsQ/B31wkh30IrRXE81W3S4xrOYuqQD3u0RnflSxnvhs+EayJEYjg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -440,18 +460,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.332.0.tgz",
-      "integrity": "sha512-DTW6d6rcqizPVyvcIrwvxecQ7e5GONtVc5Wyf0RTfqf41sDOVZYmn6G+zEFSpBLW0975uZbJS0lyLWtJe2VujQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.352.0.tgz",
+      "integrity": "sha512-lnQUJznvOhI2er1u/OVf99/2JIyDH7W+6tfWNXEoVgEi4WXtdyZ+GpPNoZsmCtHB2Jwlsh51IxmYdCj6b6SdwQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/credential-provider-process": "3.329.0",
-        "@aws-sdk/credential-provider-sso": "3.332.0",
-        "@aws-sdk/credential-provider-web-identity": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.352.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -459,19 +479,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.332.0.tgz",
-      "integrity": "sha512-KkBayS9k4WyJTvC86ngeRM+RmWxNCS1BHvudkR6PLXfnsNPDzxySDVY0UgxVhbNYDYsO561fXZt9ccpKyVWjgg==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.352.0.tgz",
+      "integrity": "sha512-8UZ5EQpoqHCh+XSGq2CdhzHZyKLOwF1taDw5A/gmV4O5lAWL0AGs0cPIEUORJyggU6Hv43zZOpLgK6dMgWOLgA==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/credential-provider-ini": "3.332.0",
-        "@aws-sdk/credential-provider-process": "3.329.0",
-        "@aws-sdk/credential-provider-sso": "3.332.0",
-        "@aws-sdk/credential-provider-web-identity": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.352.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.352.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -479,13 +499,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.329.0.tgz",
-      "integrity": "sha512-5oO220qoFc2pMdZDQa6XN/mVhp669I3+LqMbbscGtX/UgLJPSOb7YzPld9Wjv12L5rf+sD3G1PF3LZXO0vKLFA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -493,15 +513,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.332.0.tgz",
-      "integrity": "sha512-SaKXl48af3n6LRitcaEqbeg1YDXwQ0A5QziC1xQyYPraEIj3IZ/GyTjx04Lo2jxNYHuEOE8u4aTw1+IK1GDKbg==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.352.0.tgz",
+      "integrity": "sha512-YiooGNy9LYN1bFqKwO2wHC++1pYReiSqQDWBeluJfC3uZWpCyIUMdeYBR1X3XZDVtK6bl5KmhxldxJ3ntt/Q4w==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.332.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/token-providers": "3.332.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/client-sso": "3.352.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.352.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -509,36 +529,47 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.329.0.tgz",
-      "integrity": "sha512-lcEibZD7AlutCacpQ6DyNUqElZJDq+ylaIo5a8MH9jGh7Pg2WpDg0Sy+B6FbGCkVn4eIjdHxeX54JM245nhESg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.329.0.tgz",
-      "integrity": "sha512-9jfIeJhYCcTX4ScXOueRTB3S/tVce0bRsKxKDP0PnTxnGYOwKXoM9lAPmiYItzYmQ/+QzjTI8xfkA9Usz2SK/Q==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/querystring-builder": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.329.0.tgz",
-      "integrity": "sha512-6RmnWXNWpi7yAs0oRDQlkMn2wfXOStr/8kTCgiAiqrk1KopGSBkC2veKiKRSfv02FTd1yV/ISqYNIRqW1VLyxg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-buffer-from": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
@@ -548,11 +579,11 @@
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.329.0.tgz",
-      "integrity": "sha512-UXynGusDxN/HxLma5ByJ7u+XnuMd47NbHOjJgYsaAjb1CVZT7hEPXOB+mcZ+Ku7To5SCOKu2QbRn7m4bGespBg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -568,12 +599,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.329.0.tgz",
-      "integrity": "sha512-7kCd+CvY/4KbyXB0uyL7jCwPjMi2yERMALFdEH9dsUciwmxIQT6eSc4aF6wImC4UrbafaqmXvvHErABKMVBTKA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -581,14 +612,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.329.0.tgz",
-      "integrity": "sha512-hdJRoNdCM0BT4W+rrtee+kfFRgGPGXQDgtbIQlf/FuuuYz2sdef7/SYWr0mxuncnVBW5WkYSPP8h6q07whSKbg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -596,12 +627,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.329.0.tgz",
-      "integrity": "sha512-JrHeUdTIpTCfXDo9JpbAbZTS1x4mt63CCytJRq0mpWp+FlP9hjckBcNxWdR/wSKEzP9pDRnTri638BOwWH7O8w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -609,11 +640,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.329.0.tgz",
-      "integrity": "sha512-lKeeTXsYC1NiwmxrXsZepcwNXPoQxTNNbeD1qaCELPGK2cJlrGoeAP2YRWzpwO2kNZWrDLaGAPT/EUEhqw+d1w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -621,12 +652,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.329.0.tgz",
-      "integrity": "sha512-0/TYOJwrj1Z8s+Y7thibD23hggBq/K/01NwPk32CwWG/G+1vWozs5DefknEl++w0vuV+39pkY4KHI8m/+wOCpg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -634,15 +665,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.329.0.tgz",
-      "integrity": "sha512-cB3D7GlhHUcHGOlygOYxD9cPhwsTYEAMcohK38An8+RHNp6VQEWezzLFCmHVKUSeCQ+wkjZfPA40jOG0rbjSgQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/service-error-classification": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
@@ -651,12 +682,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.329.0.tgz",
-      "integrity": "sha512-bqtZuhkH8pANb2Gb4FEM1p27o+BoDBmVhEWm8sWH+APsyOor3jc6eUG2GxkfoO6D5tGNIuyCC/GuvW9XDIe4Kg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -664,11 +695,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.329.0.tgz",
-      "integrity": "sha512-tvM9NdPuRPCozPjTGNOeYZeLlyx3BcEyajrkRorCRf1YzG/mXdB6I1stote7i4q1doFtYTz0sYL8bqW3LUPn9A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -676,15 +707,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.329.0.tgz",
-      "integrity": "sha512-bL1nI+EUcF5B1ipwDXxiKL+Uw02Mbt/TNX54PbzunBGZIyO6DZG/H+M3U296bYbvPlwlZhp26O830g6K7VEWsA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/signature-v4": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -692,9 +723,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.329.0.tgz",
-      "integrity": "sha512-2huFLhJ45td2nuiIOjpc9JKJbFNn5CYmw9U8YDITTcydpteRN62CzCpeqroDvF89VOLWxh0ZFtuLCGUr7liSWQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -703,13 +734,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.332.0.tgz",
-      "integrity": "sha512-rSL1xP4QmcMOsunN1p5ZDR9GT3vvoSCnYa4iPvMSjP8Jx7l4ff/aVctwfZkMs/up12+68Jqwj4TvtaCvCFXdUA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -717,13 +748,13 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.329.0.tgz",
-      "integrity": "sha512-hg9rGNlkzh8aeR/sQbijrkFx2BIO53j4Z6qDxPNWwSGpl05jri1VHxHx2HZMwgbY6Zy/DSguETN/BL8vdFqyLg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -731,14 +762,14 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.329.0.tgz",
-      "integrity": "sha512-OrjaHjU2ZTPfoHa5DruRvTIbeHH/cc0wvh4ml+FwDpWaPaBpOhLiluhZ3anqX1l5QjrXNiQnL8FxSM5OV/zVCA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/querystring-builder": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -746,11 +777,11 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.329.0.tgz",
-      "integrity": "sha512-1cHLTV6yyMGaMSWWDW/p4vTkJ1cc5BOEO+A0eHuAcoSOk+LDe9IKhUG3/ZOvvYKQYcqIj5jjGSni/noXNCl/qw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -758,11 +789,11 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.329.0.tgz",
-      "integrity": "sha512-0rLEHY6QTHTUUcVxzGbPUSmCKlXWplxT/fcYRh0bcc5MBK4naKfcQft1O6Ajp8uqs/9YPZ7XCVCn90pDeJfeaw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -770,11 +801,11 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.329.0.tgz",
-      "integrity": "sha512-UWgMKkS5trliaDJG4nPv3onu8Y0aBuwRo7RdIgggguOiU8pU6pq1I113nH2FBNWy+Me1bwf+bcviJh0pCo6bEg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-uri-escape": "3.310.0",
         "tslib": "^2.5.0"
       },
@@ -783,11 +814,11 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.329.0.tgz",
-      "integrity": "sha512-9mkK+FB7snJ2G7H3CqtprDwYIRhzm6jEezffCwUWrC+lbqHBbErbhE9IeU/MKxILmf0RbC2riXEY1MHGspjRrQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -795,19 +826,19 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.329.0.tgz",
-      "integrity": "sha512-TSNr0flOcCLe71aPp7MjblKNGsmxpTU4xR5772MDX9Cz9GUTNZCPFtvrcqd+wzEPP/AC7XwNXe8KjoXooZImUQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.329.0.tgz",
-      "integrity": "sha512-e0hyd75fbjMd4aCoRwpP2/HR+0oScwogErVArIkq3F42c/hyNCQP3sph4JImuXIjuo6HNnpKpf20CEPPhNna8A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -815,14 +846,15 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.329.0.tgz",
-      "integrity": "sha512-9EnLoyOD5nFtCRAp+QRllDgQASCfY7jLHVhwht7jzwE80wE65Z9Ym5Z/mwTd4IyTz/xXfCvcE2VwClsBt0Ybdw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
       "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
         "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "@aws-sdk/util-uri-escape": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
@@ -832,12 +864,12 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.329.0.tgz",
-      "integrity": "sha512-7E0fGpBKxwFqHHAOqNbgNsHSEmCZLuvmU9yvG9DXKVzrS4P48O/PfOro123WpcFZs3STyOVgH8wjUPftHAVKmg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -845,14 +877,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.332.0.tgz",
-      "integrity": "sha512-fccbg6OSl0l658pxl2p1MoU9gEePo5B361+JNaN0zfRMu7c5HBXCpdl4djlFxAHjltrX9f1+BKqfGHYgI3h8SQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.352.0.tgz",
+      "integrity": "sha512-cmmAgieLP/aAl9WdPiBoaC0Abd6KncSLig/ElLPoNsADR10l3QgxQcVF3YMtdX0U0d917+/SeE1PdrPD2x15cw==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.332.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/client-sso-oidc": "3.352.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -860,9 +892,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.329.0.tgz",
-      "integrity": "sha512-wFBW4yciDfzQBSFmWNaEvHShnSGLMxSu9Lls6EUf6xDMavxSB36bsrVRX6CyAo/W0NeIIyEOW1LclGPgJV1okg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -871,12 +903,12 @@
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.329.0.tgz",
-      "integrity": "sha512-/VcfL7vNJKJGSjYYHVQF3bYCDFs4fSzB7j5qeVDwRdWr870gE7O1Dar+sLWBRKFF3AX+4VzplqzUfpu9t44JVA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -935,12 +967,12 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.329.0.tgz",
-      "integrity": "sha512-2iSiy/pzX3OXMhtSxtAzOiEFr3viQEFnYOTeZuiheuyS+cea2L79F6SlZ1110b/nOIU/UOrxxtz83HVad8YFMQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -949,15 +981,15 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.329.0.tgz",
-      "integrity": "sha512-7A6C7YKjkZtmKtH29isYEtOCbhd7IcXPP8lftN8WAWlLOiZE4gV7PHveagUj7QserJzgRKGwwTQbBj53n18HYg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -965,11 +997,11 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.332.0.tgz",
-      "integrity": "sha512-nQx7AiOroMU2hj6h+umWOSZ+WECwxupaxFUK/PPKGW6NY/VdQE6LluYnXOtF5awlr8w1nPksT0Lq05PZutMDLA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -999,9 +1031,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.329.0.tgz",
-      "integrity": "sha512-RhBOBaxzkTUghi4MSqr8S5qeeBCjgJ0XPJ6jIYkVkj1saCmqkuZCgl3zFaYdyhdxxPV6nflkFer+1HUoqT+Fqw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1010,11 +1042,11 @@
       }
     },
     "node_modules/@aws-sdk/util-retry": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.329.0.tgz",
-      "integrity": "sha512-+3VQ9HZLinysnmryUs9Xjt1YVh4TYYHLt30ilu4iUnIHFQoamdzIbRCWseSVFPCxGroen9M9qmAleAsytHEKuA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
       "dependencies": {
-        "@aws-sdk/service-error-classification": "3.329.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1033,22 +1065,22 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.329.0.tgz",
-      "integrity": "sha512-8hLSmMCl8aw2++0Zuba8ELq8FkK6/VNyx470St201IpMn2GMbQMDl/rLolRKiTgji6wc+T3pOTidkJkz8/cIXA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
       "dependencies": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.329.0.tgz",
-      "integrity": "sha512-C50Zaeodc0+psEP+L4WpElrH8epuLWJPVN4hDOTORcM0cSoU2o025Ost9mbcU7UdoHNxF9vitLnzORGN9SHolg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2281,6 +2313,29 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "dependencies": {
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@teppeis/multimaps": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-2.0.0.tgz",
@@ -2315,9 +2370,9 @@
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.115",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.115.tgz",
-      "integrity": "sha512-kCZuFXKLV3y8NjSoaD5+qKTpRWvPz3uh3W/u1uwlw3Mg+MtaStg1NWgjAwUXo/VJDb6n6KF1ljykFNlNwEJ53Q==",
+      "version": "8.10.117",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.117.tgz",
+      "integrity": "sha512-6T1aHTSSK4l8+67ANKHha/CRVxyk/bAl6OGCOxsKVsHaSxWpqsqgupc8rPw8vQGjtIgIZ+EaHqMz8gA4d6xZhQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -2395,9 +2450,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
-      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "version": "29.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
+      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -2411,15 +2466,15 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.7.tgz",
-      "integrity": "sha512-MFg7ua/bRtnA1hYE3pVyWxGd/r7aMqjNOdHvlSsXV3n8iaeGKkOaPzpJh6/ovf4bEXWcojkeMJpTsq3mzXW4IQ==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -2569,9 +2624,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.79.1.tgz",
-      "integrity": "sha512-N6intzdRFqrHC+O3Apty34RiTev2+bzvRtUbehVd5IyAmTvLsgE/jlhPUIJV2POSAK+bKOV+ZWEp9qMOj1hq8A==",
+      "version": "2.83.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.83.1.tgz",
+      "integrity": "sha512-hM2fsHl2TXk3B0MTq7zRU/KqJiVrnTQ3SXbAfleQCfCf/Jpy6yD6nGqrEADFAYNLSPoA9iC3SLnO73SPqqjjRQ==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2584,9 +2639,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.79.1.tgz",
-      "integrity": "sha512-iOPT9hbpP7z9otAzAgSr3HksjZe/QQXdyE7P1A4EESAzmLktOGfzzHydJqU1wfE9BbgK4ioCS0dJ3EaCCtWGpg==",
+      "version": "2.83.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.83.1.tgz",
+      "integrity": "sha512-bFYXJDRyuH9x/xmANucKiEzzAbF683XDKOEmSivEgIkGP3zYkZ6beWajSAOQqRsm1VOPjgcpFuJtggUOkdPVKg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2600,9 +2655,9 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.165",
+        "@aws-cdk/asset-awscli-v1": "^2.2.177",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.139",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.1.1",
@@ -2610,7 +2665,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.5.0",
+        "semver": "^7.5.1",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -2826,7 +2881,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.0",
+      "version": "7.5.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3161,9 +3216,9 @@
       }
     },
     "node_modules/cdk-nag": {
-      "version": "2.27.8",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.27.8.tgz",
-      "integrity": "sha512-QTgMYFDv6PA+xL+8Mo6+KpxlgWdLNanhW7QZSNAmigmptY6wc72/+7ihHUiqv7pasNcatOdOlGkJ0bpHVHM0iw==",
+      "version": "2.27.37",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.27.37.tgz",
+      "integrity": "sha512-l/9gNyV1bA0OqdFatTsWFcccUlEsxYDblGfrqNyUw+nvAH5f4y5l6wxhvmH7jkQ8w6XriXKeBFkuc0Gl1/YAVw==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.78.0",
         "constructs": "^10.0.5"
@@ -3323,9 +3378,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.2.24",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.24.tgz",
-      "integrity": "sha512-35U5rfqCm800L98WwAgsig3jfy0ACOenjEh3o9t95kXvpGqviQO28HyERm9hCgtGVT8xZzczPNAZoVWkDbntzg==",
+      "version": "10.2.52",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.52.tgz",
+      "integrity": "sha512-+agHle0qck/Z2ARWtI8WpAiFzBFweti2ai03ShK3R708WTmny+HO97joPQ99oQQvmHaAgCZmAqEUufeySk9J0Q==",
       "engines": {
         "node": ">= 16.14.0"
       }
@@ -3566,18 +3621,24 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
         "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fb-watchman": {
@@ -5349,7 +5410,6 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5364,7 +5424,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5375,8 +5434,7 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5782,16 +5840,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6059,9 +6117,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.168",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.168.tgz",
-      "integrity": "sha512-w0NQAhoeqqTwcf9HoO+NaSval1fGQcxByFg+z6sHT/gkpyrsnuR23dGRY4ARBUWL1DUyjWYptFe0CFyy1Vdmsg=="
+      "version": "2.2.190",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.190.tgz",
+      "integrity": "sha512-Q/PiNMbs073DO0Qg5d/cs/X2qZylqiuOwAfTRMUgOqNrUEIwPnAHQNtH0gmYWsCSKkttQG929WmBtivlK6NRhA=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -6069,22 +6127,39 @@
       "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.141",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.141.tgz",
-      "integrity": "sha512-+Yu9Ij3jrIoyuYlx71rfBMeiTmS3YCrhvhGKNLwYvOTrij5ZTO+b3FYlrN/J31Bx8tRQrDlR75ERbxt4Wb/v9A=="
+      "version": "2.0.164",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.164.tgz",
+      "integrity": "sha512-mqK5sGcnjTuPLdhvGqSueSObGFMszYsfe1wKFlbeaoJWG47ngO8AQXnM7CboPUpvCajcig3aITuKvuZ27+FM+Q=="
     },
     "@aws-cdk/aws-apigatewayv2-alpha": {
-      "version": "2.79.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.79.1-alpha.0.tgz",
-      "integrity": "sha512-B5MDJjIa7DmykRxLYu1k2tnLNxllg4hwRWWgsMn+2xgXyZ0xmmdrxCXaAUx+SBiCxxpvumS3ukAGq7u5eYHvvA==",
+      "version": "2.83.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.83.1-alpha.0.tgz",
+      "integrity": "sha512-4pX4H3Ez4hCjPsJO4FMYtj561GyWQG058igNKAI6zCJlkz858T47YOCwRtDhwUg65D5hEiEB46wd/F8eGfosoA==",
       "peer": true,
       "requires": {}
     },
     "@aws-cdk/aws-apigatewayv2-authorizers-alpha": {
-      "version": "2.79.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.79.1-alpha.0.tgz",
-      "integrity": "sha512-H+fb2cP7Fs5tQMBww/hz4w+OKP4eELBB3uhgPUv7LE/frcnKfaoXum6tCj1xfb+SkaieiMbyxBx2JXAiUX/GGQ==",
+      "version": "2.83.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-authorizers-alpha/-/aws-apigatewayv2-authorizers-alpha-2.83.1-alpha.0.tgz",
+      "integrity": "sha512-6568fNxpb2EWlwwuNbvRZyRzFB4GKDzaVl1uwZVtTB8aEEnf+M6KYyTL5ez4NRXlq+t8xUt8utMBANFY8ttJbg==",
       "requires": {}
+    },
+    "@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
     },
     "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
@@ -6173,349 +6248,365 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.329.0.tgz",
-      "integrity": "sha512-hzrjPNQcJoSPe0oS20V5i98oiEZSM3mKNiR6P3xHTHTPI/F23lyjGZ+/CSkCmJbSWfGZ5sHZZcU6AWuS7xBdTw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.347.0.tgz",
+      "integrity": "sha512-P/2qE6ntYEmYG4Ez535nJWZbXqgbkJx8CMz7ChEuEg3Gp3dvVYEKg+iEUEvlqQ2U5dWP5J3ehw5po9t86IsVPQ==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.332.0.tgz",
-      "integrity": "sha512-uzVAfIFXnc+qDFCx1IehpRFVWVXleIogkmnKKS1gHS5LZ0Nr0b+QZmy/Ip6dfcG6UJ9P8eM5Or0R8HJk1NLwgA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.352.0.tgz",
+      "integrity": "sha512-FOc/vjUMHzMTp4Cc/oV6nKbtnJclS6IqWr1H4kNrjRQBdgrGJtb0YT8gLtyKF+J323QrTZVus31P/AkjfSmxgA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.332.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.332.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/client-sts": "3.352.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.332.0.tgz",
-      "integrity": "sha512-xn8Ft+y+XggryvvPnKSEYhuidxWMMAXTfM4Dk1HAbzrpyAYRIuvYApt0a9nWa9DNM6Oi0yhcVvmsJW0/R+tvcA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.352.0.tgz",
+      "integrity": "sha512-P3RuTBlst0+/iKY3XcF3OxFy4k7zD/PYqLG2Gf02FED20EVrZIbc1ZJxSqP6+4tVZI6H3ql9eYyHPHJ60rMNrg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.332.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.332.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/client-sts": "3.352.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.332.0.tgz",
-      "integrity": "sha512-4q1Nko8M6YVANdEiLYvdv1qb00j4xN4ppE/6d4xpGp7DxHYlm0GA762h0/TR2dun+2I+SMnwj4Fv6BxOmzBaEw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.352.0.tgz",
+      "integrity": "sha512-oeO36rvRvYbUlsgzYtLI2/BPwXdUK4KtYw+OFmirYeONUyX5uYx8kWXD66r3oXViIYMqhyHKN3fhkiFmFcVluQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.332.0.tgz",
-      "integrity": "sha512-tz8k8Yqm4TScIfit0Tum2zWAq1md+gZKr747CSixd4Zwcp7Vwh75cRoL7Rz1ZHSEn1Yo983MWREevVez3SubLw==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.352.0.tgz",
+      "integrity": "sha512-PQdp0KOr478CaJNohASTgtt03W8Y/qINwsalLNguK01tWIGzellg2N3bA+IdyYXU8Oz3+Ab1oIJMKkUxtuNiGg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.332.0.tgz",
-      "integrity": "sha512-uVobnXIzMcEhwBDyk6iOt36N/TRNI8hwq7MQugjYGj7Inma9g4vnR09hXJ24HxyKCoVUoIgMbEguQ43+/+uvDQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.352.0.tgz",
+      "integrity": "sha512-Lt7uSdwgOrwYx8S6Bhz76ewOeoJNFiPD+Q7v8S/mJK8T7HUE/houjomXC3UnFaJjcecjWv273zEqV67FgP5l5g==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-node": "3.332.0",
-        "@aws-sdk/fetch-http-handler": "3.329.0",
-        "@aws-sdk/hash-node": "3.329.0",
-        "@aws-sdk/invalid-dependency": "3.329.0",
-        "@aws-sdk/middleware-content-length": "3.329.0",
-        "@aws-sdk/middleware-endpoint": "3.329.0",
-        "@aws-sdk/middleware-host-header": "3.329.0",
-        "@aws-sdk/middleware-logger": "3.329.0",
-        "@aws-sdk/middleware-recursion-detection": "3.329.0",
-        "@aws-sdk/middleware-retry": "3.329.0",
-        "@aws-sdk/middleware-sdk-sts": "3.329.0",
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/middleware-user-agent": "3.332.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/node-http-handler": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/smithy-client": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-node": "3.352.0",
+        "@aws-sdk/fetch-http-handler": "3.347.0",
+        "@aws-sdk/hash-node": "3.347.0",
+        "@aws-sdk/invalid-dependency": "3.347.0",
+        "@aws-sdk/middleware-content-length": "3.347.0",
+        "@aws-sdk/middleware-endpoint": "3.347.0",
+        "@aws-sdk/middleware-host-header": "3.347.0",
+        "@aws-sdk/middleware-logger": "3.347.0",
+        "@aws-sdk/middleware-recursion-detection": "3.347.0",
+        "@aws-sdk/middleware-retry": "3.347.0",
+        "@aws-sdk/middleware-sdk-sts": "3.347.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/middleware-user-agent": "3.352.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/node-http-handler": "3.350.0",
+        "@aws-sdk/smithy-client": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "@aws-sdk/util-body-length-browser": "3.310.0",
         "@aws-sdk/util-body-length-node": "3.310.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.329.0",
-        "@aws-sdk/util-defaults-mode-node": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
-        "@aws-sdk/util-retry": "3.329.0",
-        "@aws-sdk/util-user-agent-browser": "3.329.0",
-        "@aws-sdk/util-user-agent-node": "3.329.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.347.0",
+        "@aws-sdk/util-defaults-mode-node": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
+        "@aws-sdk/util-retry": "3.347.0",
+        "@aws-sdk/util-user-agent-browser": "3.347.0",
+        "@aws-sdk/util-user-agent-node": "3.347.0",
         "@aws-sdk/util-utf8": "3.310.0",
-        "fast-xml-parser": "4.1.2",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.2.4",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.329.0.tgz",
-      "integrity": "sha512-Oj6eiT3q+Jn685yvUrfRi8PhB3fb81hasJqdrsEivA8IP8qAgnVUTJzXsh8O2UX8UM2MF6A1gTgToSgneJuw2Q==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.347.0.tgz",
+      "integrity": "sha512-2ja+Sf/VnUO7IQ3nKbDQ5aumYKKJUaTm/BuVJ29wNho8wYHfuf7wHZV0pDTkB8RF5SH7IpHap7zpZAj39Iq+EA==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-config-provider": "3.310.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.329.0.tgz",
-      "integrity": "sha512-B4orC9hMt9hG82vAR0TAnQqjk6cFDbO2S14RdzUj2n2NPlGWW4Blkv3NTo86K0lq011VRhtqaLcuTwn5EJD5Sg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.347.0.tgz",
+      "integrity": "sha512-UnEM+LKGpXKzw/1WvYEQsC6Wj9PupYZdQOE+e2Dgy2dqk/pVFy4WueRtFXYDT2B41ppv3drdXUuKZRIDVqIgNQ==",
       "requires": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.329.0.tgz",
-      "integrity": "sha512-ggPlnd7QROPTid0CwT01TYYGvstRRTpzTGsQ/B31wkh30IrRXE81W3S4xrOYuqQD3u0RnflSxnvhs+EayJEYjg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.347.0.tgz",
+      "integrity": "sha512-7scCy/DCDRLIhlqTxff97LQWDnRwRXji3bxxMg+xWOTTaJe7PWx+etGSbBWaL42vsBHFShQjSLvJryEgoBktpw==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.332.0.tgz",
-      "integrity": "sha512-DTW6d6rcqizPVyvcIrwvxecQ7e5GONtVc5Wyf0RTfqf41sDOVZYmn6G+zEFSpBLW0975uZbJS0lyLWtJe2VujQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.352.0.tgz",
+      "integrity": "sha512-lnQUJznvOhI2er1u/OVf99/2JIyDH7W+6tfWNXEoVgEi4WXtdyZ+GpPNoZsmCtHB2Jwlsh51IxmYdCj6b6SdwQ==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/credential-provider-process": "3.329.0",
-        "@aws-sdk/credential-provider-sso": "3.332.0",
-        "@aws-sdk/credential-provider-web-identity": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.352.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.332.0.tgz",
-      "integrity": "sha512-KkBayS9k4WyJTvC86ngeRM+RmWxNCS1BHvudkR6PLXfnsNPDzxySDVY0UgxVhbNYDYsO561fXZt9ccpKyVWjgg==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.352.0.tgz",
+      "integrity": "sha512-8UZ5EQpoqHCh+XSGq2CdhzHZyKLOwF1taDw5A/gmV4O5lAWL0AGs0cPIEUORJyggU6Hv43zZOpLgK6dMgWOLgA==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/credential-provider-ini": "3.332.0",
-        "@aws-sdk/credential-provider-process": "3.329.0",
-        "@aws-sdk/credential-provider-sso": "3.332.0",
-        "@aws-sdk/credential-provider-web-identity": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/credential-provider-env": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/credential-provider-ini": "3.352.0",
+        "@aws-sdk/credential-provider-process": "3.347.0",
+        "@aws-sdk/credential-provider-sso": "3.352.0",
+        "@aws-sdk/credential-provider-web-identity": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.329.0.tgz",
-      "integrity": "sha512-5oO220qoFc2pMdZDQa6XN/mVhp669I3+LqMbbscGtX/UgLJPSOb7YzPld9Wjv12L5rf+sD3G1PF3LZXO0vKLFA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.347.0.tgz",
+      "integrity": "sha512-yl1z4MsaBdXd4GQ2halIvYds23S67kElyOwz7g8kaQ4kHj+UoYWxz3JVW/DGusM6XmQ9/F67utBrUVA0uhQYyw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.332.0.tgz",
-      "integrity": "sha512-SaKXl48af3n6LRitcaEqbeg1YDXwQ0A5QziC1xQyYPraEIj3IZ/GyTjx04Lo2jxNYHuEOE8u4aTw1+IK1GDKbg==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.352.0.tgz",
+      "integrity": "sha512-YiooGNy9LYN1bFqKwO2wHC++1pYReiSqQDWBeluJfC3uZWpCyIUMdeYBR1X3XZDVtK6bl5KmhxldxJ3ntt/Q4w==",
       "requires": {
-        "@aws-sdk/client-sso": "3.332.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/token-providers": "3.332.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/client-sso": "3.352.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/token-providers": "3.352.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.329.0.tgz",
-      "integrity": "sha512-lcEibZD7AlutCacpQ6DyNUqElZJDq+ylaIo5a8MH9jGh7Pg2WpDg0Sy+B6FbGCkVn4eIjdHxeX54JM245nhESg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.347.0.tgz",
+      "integrity": "sha512-DxoTlVK8lXjS1zVphtz/Ab+jkN/IZor9d6pP2GjJHNoAIIzXfRwwj5C8vr4eTayx/5VJ7GRP91J8GJ2cKly8Qw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.347.0.tgz",
+      "integrity": "sha512-61q+SyspjsaQ4sdgjizMyRgVph2CiW4aAtfpoH69EJFJfTxTR/OqnZ9Jx/3YiYi0ksrvDenJddYodfWWJqD8/w==",
+      "requires": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.329.0.tgz",
-      "integrity": "sha512-9jfIeJhYCcTX4ScXOueRTB3S/tVce0bRsKxKDP0PnTxnGYOwKXoM9lAPmiYItzYmQ/+QzjTI8xfkA9Usz2SK/Q==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.347.0.tgz",
+      "integrity": "sha512-sQ5P7ivY8//7wdxfA76LT1sF6V2Tyyz1qF6xXf9sihPN5Q1Y65c+SKpMzXyFSPqWZ82+SQQuDliYZouVyS6kQQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/querystring-builder": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-base64": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.329.0.tgz",
-      "integrity": "sha512-6RmnWXNWpi7yAs0oRDQlkMn2wfXOStr/8kTCgiAiqrk1KopGSBkC2veKiKRSfv02FTd1yV/ISqYNIRqW1VLyxg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.347.0.tgz",
+      "integrity": "sha512-96+ml/4EaUaVpzBdOLGOxdoXOjkPgkoJp/0i1fxOJEvl8wdAQSwc3IugVK9wZkCxy2DlENtgOe6DfIOhfffm/g==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-buffer-from": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.329.0.tgz",
-      "integrity": "sha512-UXynGusDxN/HxLma5ByJ7u+XnuMd47NbHOjJgYsaAjb1CVZT7hEPXOB+mcZ+Ku7To5SCOKu2QbRn7m4bGespBg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.347.0.tgz",
+      "integrity": "sha512-8imQcwLwqZ/wTJXZqzXT9pGLIksTRckhGLZaXT60tiBOPKuerTsus2L59UstLs5LP8TKaVZKFFSsjRIn9dQdmQ==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6528,246 +6619,247 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.329.0.tgz",
-      "integrity": "sha512-7kCd+CvY/4KbyXB0uyL7jCwPjMi2yERMALFdEH9dsUciwmxIQT6eSc4aF6wImC4UrbafaqmXvvHErABKMVBTKA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.347.0.tgz",
+      "integrity": "sha512-i4qtWTDImMaDUtwKQPbaZpXsReiwiBomM1cWymCU4bhz81HL01oIxOxOBuiM+3NlDoCSPr3KI6txZSz/8cqXCQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.329.0.tgz",
-      "integrity": "sha512-hdJRoNdCM0BT4W+rrtee+kfFRgGPGXQDgtbIQlf/FuuuYz2sdef7/SYWr0mxuncnVBW5WkYSPP8h6q07whSKbg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.347.0.tgz",
+      "integrity": "sha512-unF0c6dMaUL1ffU+37Ugty43DgMnzPWXr/Jup/8GbK5fzzWT5NQq6dj9KHPubMbWeEjQbmczvhv25JuJdK8gNQ==",
       "requires": {
-        "@aws-sdk/middleware-serde": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/url-parser": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/middleware-serde": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/url-parser": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.329.0.tgz",
-      "integrity": "sha512-JrHeUdTIpTCfXDo9JpbAbZTS1x4mt63CCytJRq0mpWp+FlP9hjckBcNxWdR/wSKEzP9pDRnTri638BOwWH7O8w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.347.0.tgz",
+      "integrity": "sha512-kpKmR9OvMlnReqp5sKcJkozbj1wmlblbVSbnQAIkzeQj2xD5dnVR3Nn2ogQKxSmU1Fv7dEroBtrruJ1o3fY38A==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.329.0.tgz",
-      "integrity": "sha512-lKeeTXsYC1NiwmxrXsZepcwNXPoQxTNNbeD1qaCELPGK2cJlrGoeAP2YRWzpwO2kNZWrDLaGAPT/EUEhqw+d1w==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.347.0.tgz",
+      "integrity": "sha512-NYC+Id5UCkVn+3P1t/YtmHt75uED06vwaKyxDy0UmB2K66PZLVtwWbLpVWrhbroaw1bvUHYcRyQ9NIfnVcXQjA==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.329.0.tgz",
-      "integrity": "sha512-0/TYOJwrj1Z8s+Y7thibD23hggBq/K/01NwPk32CwWG/G+1vWozs5DefknEl++w0vuV+39pkY4KHI8m/+wOCpg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.347.0.tgz",
+      "integrity": "sha512-qfnSvkFKCAMjMHR31NdsT0gv5Sq/ZHTUD4yQsSLpbVQ6iYAS834lrzXt41iyEHt57Y514uG7F/Xfvude3u4icQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.329.0.tgz",
-      "integrity": "sha512-cB3D7GlhHUcHGOlygOYxD9cPhwsTYEAMcohK38An8+RHNp6VQEWezzLFCmHVKUSeCQ+wkjZfPA40jOG0rbjSgQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.347.0.tgz",
+      "integrity": "sha512-CpdM+8dCSbX96agy4FCzOfzDmhNnGBM/pxrgIVLm5nkYTLuXp/d7ubpFEUHULr+4hCd5wakHotMt7yO29NFaVw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/service-error-classification": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
-        "@aws-sdk/util-retry": "3.329.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
+        "@aws-sdk/util-retry": "3.347.0",
         "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.329.0.tgz",
-      "integrity": "sha512-bqtZuhkH8pANb2Gb4FEM1p27o+BoDBmVhEWm8sWH+APsyOor3jc6eUG2GxkfoO6D5tGNIuyCC/GuvW9XDIe4Kg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.347.0.tgz",
+      "integrity": "sha512-38LJ0bkIoVF3W97x6Jyyou72YV9Cfbml4OaDEdnrCOo0EssNZM5d7RhjMvQDwww7/3OBY/BzeOcZKfJlkYUXGw==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/middleware-signing": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.329.0.tgz",
-      "integrity": "sha512-tvM9NdPuRPCozPjTGNOeYZeLlyx3BcEyajrkRorCRf1YzG/mXdB6I1stote7i4q1doFtYTz0sYL8bqW3LUPn9A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.347.0.tgz",
+      "integrity": "sha512-x5Foi7jRbVJXDu9bHfyCbhYDH5pKK+31MmsSJ3k8rY8keXLBxm2XEEg/AIoV9/TUF9EeVvZ7F1/RmMpJnWQsEg==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.329.0.tgz",
-      "integrity": "sha512-bL1nI+EUcF5B1ipwDXxiKL+Uw02Mbt/TNX54PbzunBGZIyO6DZG/H+M3U296bYbvPlwlZhp26O830g6K7VEWsA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.347.0.tgz",
+      "integrity": "sha512-zVBF/4MGKnvhAE/J+oAL/VAehiyv+trs2dqSQXwHou9j8eA8Vm8HS2NdOwpkZQchIxTuwFlqSusDuPEdYFbvGw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/signature-v4": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/signature-v4": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.329.0.tgz",
-      "integrity": "sha512-2huFLhJ45td2nuiIOjpc9JKJbFNn5CYmw9U8YDITTcydpteRN62CzCpeqroDvF89VOLWxh0ZFtuLCGUr7liSWQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.347.0.tgz",
+      "integrity": "sha512-Izidg4rqtYMcKuvn2UzgEpPLSmyd8ub9+LQ2oIzG3mpIzCBITq7wp40jN1iNkMg+X6KEnX9vdMJIYZsPYMCYuQ==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.332.0.tgz",
-      "integrity": "sha512-rSL1xP4QmcMOsunN1p5ZDR9GT3vvoSCnYa4iPvMSjP8Jx7l4ff/aVctwfZkMs/up12+68Jqwj4TvtaCvCFXdUA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.352.0.tgz",
+      "integrity": "sha512-QGqblMTsVDqeomy22KPm9LUW8PHZXBA2Hjk9Hcw8U1uFS8IKYJrewInG3ae2+9FAcTyug4LFWDf8CRr9YH2B3Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
-        "@aws-sdk/util-endpoints": "3.332.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
+        "@aws-sdk/util-endpoints": "3.352.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.329.0.tgz",
-      "integrity": "sha512-hg9rGNlkzh8aeR/sQbijrkFx2BIO53j4Z6qDxPNWwSGpl05jri1VHxHx2HZMwgbY6Zy/DSguETN/BL8vdFqyLg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.347.0.tgz",
+      "integrity": "sha512-faU93d3+5uTTUcotGgMXF+sJVFjrKh+ufW+CzYKT4yUHammyaIab/IbTPWy2hIolcEGtuPeVoxXw8TXbkh/tuw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.329.0.tgz",
-      "integrity": "sha512-OrjaHjU2ZTPfoHa5DruRvTIbeHH/cc0wvh4ml+FwDpWaPaBpOhLiluhZ3anqX1l5QjrXNiQnL8FxSM5OV/zVCA==",
+      "version": "3.350.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.350.0.tgz",
+      "integrity": "sha512-oD96GAlmpzYilCdC8wwyURM5lNfNHZCjm/kxBkQulHKa2kRbIrnD9GfDqdCkWA5cTpjh1NzGLT4D6e6UFDjt9w==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.329.0",
-        "@aws-sdk/protocol-http": "3.329.0",
-        "@aws-sdk/querystring-builder": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/abort-controller": "3.347.0",
+        "@aws-sdk/protocol-http": "3.347.0",
+        "@aws-sdk/querystring-builder": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.329.0.tgz",
-      "integrity": "sha512-1cHLTV6yyMGaMSWWDW/p4vTkJ1cc5BOEO+A0eHuAcoSOk+LDe9IKhUG3/ZOvvYKQYcqIj5jjGSni/noXNCl/qw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.347.0.tgz",
+      "integrity": "sha512-t3nJ8CYPLKAF2v9nIHOHOlF0CviQbTvbFc2L4a+A+EVd/rM4PzL3+3n8ZJsr0h7f6uD04+b5YRFgKgnaqLXlEg==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.329.0.tgz",
-      "integrity": "sha512-0rLEHY6QTHTUUcVxzGbPUSmCKlXWplxT/fcYRh0bcc5MBK4naKfcQft1O6Ajp8uqs/9YPZ7XCVCn90pDeJfeaw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.347.0.tgz",
+      "integrity": "sha512-2YdBhc02Wvy03YjhGwUxF0UQgrPWEy8Iq75pfS42N+/0B/+eWX1aQgfjFxIpLg7YSjT5eKtYOQGlYd4MFTgj9g==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.329.0.tgz",
-      "integrity": "sha512-UWgMKkS5trliaDJG4nPv3onu8Y0aBuwRo7RdIgggguOiU8pU6pq1I113nH2FBNWy+Me1bwf+bcviJh0pCo6bEg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.347.0.tgz",
+      "integrity": "sha512-phtKTe6FXoV02MoPkIVV6owXI8Mwr5IBN3bPoxhcPvJG2AjEmnetSIrhb8kwc4oNhlwfZwH6Jo5ARW/VEWbZtg==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-uri-escape": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.329.0.tgz",
-      "integrity": "sha512-9mkK+FB7snJ2G7H3CqtprDwYIRhzm6jEezffCwUWrC+lbqHBbErbhE9IeU/MKxILmf0RbC2riXEY1MHGspjRrQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.347.0.tgz",
+      "integrity": "sha512-5VXOhfZz78T2W7SuXf2avfjKglx1VZgZgp9Zfhrt/Rq+MTu2D+PZc5zmJHhYigD7x83jLSLogpuInQpFMA9LgA==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.329.0.tgz",
-      "integrity": "sha512-TSNr0flOcCLe71aPp7MjblKNGsmxpTU4xR5772MDX9Cz9GUTNZCPFtvrcqd+wzEPP/AC7XwNXe8KjoXooZImUQ=="
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.347.0.tgz",
+      "integrity": "sha512-xZ3MqSY81Oy2gh5g0fCtooAbahqh9VhsF8vcKjVX8+XPbGC8y+kej82+MsMg4gYL8gRFB9u4hgYbNgIS6JTAvg=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.329.0.tgz",
-      "integrity": "sha512-e0hyd75fbjMd4aCoRwpP2/HR+0oScwogErVArIkq3F42c/hyNCQP3sph4JImuXIjuo6HNnpKpf20CEPPhNna8A==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.347.0.tgz",
+      "integrity": "sha512-Xw+zAZQVLb+xMNHChXQ29tzzLqm3AEHsD8JJnlkeFjeMnWQtXdUfOARl5s8NzAppcKQNlVe2gPzjaKjoy2jz1Q==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.329.0.tgz",
-      "integrity": "sha512-9EnLoyOD5nFtCRAp+QRllDgQASCfY7jLHVhwht7jzwE80wE65Z9Ym5Z/mwTd4IyTz/xXfCvcE2VwClsBt0Ybdw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.347.0.tgz",
+      "integrity": "sha512-58Uq1do+VsTHYkP11dTK+DF53fguoNNJL9rHRWhzP+OcYv3/mBMLoS2WPz/x9FO5mBg4ESFsug0I6mXbd36tjw==",
       "requires": {
+        "@aws-sdk/eventstream-codec": "3.347.0",
         "@aws-sdk/is-array-buffer": "3.310.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "@aws-sdk/util-hex-encoding": "3.310.0",
-        "@aws-sdk/util-middleware": "3.329.0",
+        "@aws-sdk/util-middleware": "3.347.0",
         "@aws-sdk/util-uri-escape": "3.310.0",
         "@aws-sdk/util-utf8": "3.310.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.329.0.tgz",
-      "integrity": "sha512-7E0fGpBKxwFqHHAOqNbgNsHSEmCZLuvmU9yvG9DXKVzrS4P48O/PfOro123WpcFZs3STyOVgH8wjUPftHAVKmg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.347.0.tgz",
+      "integrity": "sha512-PaGTDsJLGK0sTjA6YdYQzILRlPRN3uVFyqeBUkfltXssvUzkm8z2t1lz2H4VyJLAhwnG5ZuZTNEV/2mcWrU7JQ==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/middleware-stack": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.332.0.tgz",
-      "integrity": "sha512-fccbg6OSl0l658pxl2p1MoU9gEePo5B361+JNaN0zfRMu7c5HBXCpdl4djlFxAHjltrX9f1+BKqfGHYgI3h8SQ==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.352.0.tgz",
+      "integrity": "sha512-cmmAgieLP/aAl9WdPiBoaC0Abd6KncSLig/ElLPoNsADR10l3QgxQcVF3YMtdX0U0d917+/SeE1PdrPD2x15cw==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.332.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/shared-ini-file-loader": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/client-sso-oidc": "3.352.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/shared-ini-file-loader": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.329.0.tgz",
-      "integrity": "sha512-wFBW4yciDfzQBSFmWNaEvHShnSGLMxSu9Lls6EUf6xDMavxSB36bsrVRX6CyAo/W0NeIIyEOW1LclGPgJV1okg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.347.0.tgz",
+      "integrity": "sha512-GkCMy79mdjU9OTIe5KT58fI/6uqdf8UmMdWqVHmFJ+UpEzOci7L/uw4sOXWo7xpPzLs6cJ7s5ouGZW4GRPmHFA==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.329.0.tgz",
-      "integrity": "sha512-/VcfL7vNJKJGSjYYHVQF3bYCDFs4fSzB7j5qeVDwRdWr870gE7O1Dar+sLWBRKFF3AX+4VzplqzUfpu9t44JVA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.347.0.tgz",
+      "integrity": "sha512-lhrnVjxdV7hl+yCnJfDZOaVLSqKjxN20MIOiijRiqaWGLGEAiSqBreMhL89X1WKCifxAs4zZf9YB9SbdziRpAA==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/querystring-parser": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6814,35 +6906,35 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.329.0.tgz",
-      "integrity": "sha512-2iSiy/pzX3OXMhtSxtAzOiEFr3viQEFnYOTeZuiheuyS+cea2L79F6SlZ1110b/nOIU/UOrxxtz83HVad8YFMQ==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.347.0.tgz",
+      "integrity": "sha512-+JHFA4reWnW/nMWwrLKqL2Lm/biw/Dzi/Ix54DAkRZ08C462jMKVnUlzAI+TfxQE3YLm99EIa0G7jiEA+p81Qw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.329.0.tgz",
-      "integrity": "sha512-7A6C7YKjkZtmKtH29isYEtOCbhd7IcXPP8lftN8WAWlLOiZE4gV7PHveagUj7QserJzgRKGwwTQbBj53n18HYg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.347.0.tgz",
+      "integrity": "sha512-A8BzIVhAAZE5WEukoAN2kYebzTc99ZgncbwOmgCCbvdaYlk5tzguR/s+uoT4G0JgQGol/4hAMuJEl7elNgU6RQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.329.0",
-        "@aws-sdk/credential-provider-imds": "3.329.0",
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/property-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/config-resolver": "3.347.0",
+        "@aws-sdk/credential-provider-imds": "3.347.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/property-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.332.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.332.0.tgz",
-      "integrity": "sha512-nQx7AiOroMU2hj6h+umWOSZ+WECwxupaxFUK/PPKGW6NY/VdQE6LluYnXOtF5awlr8w1nPksT0Lq05PZutMDLA==",
+      "version": "3.352.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.352.0.tgz",
+      "integrity": "sha512-PjWMPdoIUWfBPgAWLyOrWFbdSS/3DJtc0OmFb/JrE8C8rKFYl+VGW5f1p0cVdRWiDR0xCGr0s67p8itAakVqjw==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6863,19 +6955,19 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.329.0.tgz",
-      "integrity": "sha512-RhBOBaxzkTUghi4MSqr8S5qeeBCjgJ0XPJ6jIYkVkj1saCmqkuZCgl3zFaYdyhdxxPV6nflkFer+1HUoqT+Fqw==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.347.0.tgz",
+      "integrity": "sha512-8owqUA3ePufeYTUvlzdJ7Z0miLorTwx+rNol5lourGQZ9JXsVMo23+yGA7nOlFuXSGkoKpMOtn6S0BT2bcfeiw==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-retry": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.329.0.tgz",
-      "integrity": "sha512-+3VQ9HZLinysnmryUs9Xjt1YVh4TYYHLt30ilu4iUnIHFQoamdzIbRCWseSVFPCxGroen9M9qmAleAsytHEKuA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.347.0.tgz",
+      "integrity": "sha512-NxnQA0/FHFxriQAeEgBonA43Q9/VPFQa8cfJDuT2A1YZruMasgjcltoZszi1dvoIRWSZsFTW42eY2gdOd0nffQ==",
       "requires": {
-        "@aws-sdk/service-error-classification": "3.329.0",
+        "@aws-sdk/service-error-classification": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6888,22 +6980,22 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.329.0.tgz",
-      "integrity": "sha512-8hLSmMCl8aw2++0Zuba8ELq8FkK6/VNyx470St201IpMn2GMbQMDl/rLolRKiTgji6wc+T3pOTidkJkz8/cIXA==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.347.0.tgz",
+      "integrity": "sha512-ydxtsKVtQefgbk1Dku1q7pMkjDYThauG9/8mQkZUAVik55OUZw71Zzr3XO8J8RKvQG8lmhPXuAQ0FKAyycc0RA==",
       "requires": {
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/types": "3.347.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.329.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.329.0.tgz",
-      "integrity": "sha512-C50Zaeodc0+psEP+L4WpElrH8epuLWJPVN4hDOTORcM0cSoU2o025Ost9mbcU7UdoHNxF9vitLnzORGN9SHolg==",
+      "version": "3.347.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.347.0.tgz",
+      "integrity": "sha512-6X0b9qGsbD1s80PmbaB6v1/ZtLfSx6fjRX8caM7NN0y/ObuLoX8LhYnW6WlB2f1+xb4EjaCNgpP/zCf98MXosw==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.329.0",
-        "@aws-sdk/types": "3.329.0",
+        "@aws-sdk/node-config-provider": "3.347.0",
+        "@aws-sdk/types": "3.347.0",
         "tslib": "^2.5.0"
       }
     },
@@ -7878,6 +7970,23 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "@smithy/protocol-http": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "requires": {
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@smithy/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
     "@teppeis/multimaps": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-2.0.0.tgz",
@@ -7909,9 +8018,9 @@
       "dev": true
     },
     "@types/aws-lambda": {
-      "version": "8.10.115",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.115.tgz",
-      "integrity": "sha512-kCZuFXKLV3y8NjSoaD5+qKTpRWvPz3uh3W/u1uwlw3Mg+MtaStg1NWgjAwUXo/VJDb6n6KF1ljykFNlNwEJ53Q==",
+      "version": "8.10.117",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.117.tgz",
+      "integrity": "sha512-6T1aHTSSK4l8+67ANKHha/CRVxyk/bAl6OGCOxsKVsHaSxWpqsqgupc8rPw8vQGjtIgIZ+EaHqMz8gA4d6xZhQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -7989,9 +8098,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
-      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "version": "29.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
+      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",
@@ -8005,15 +8114,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.7.tgz",
-      "integrity": "sha512-MFg7ua/bRtnA1hYE3pVyWxGd/r7aMqjNOdHvlSsXV3n8iaeGKkOaPzpJh6/ovf4bEXWcojkeMJpTsq3mzXW4IQ==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -8133,22 +8242,22 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-cdk": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.79.1.tgz",
-      "integrity": "sha512-N6intzdRFqrHC+O3Apty34RiTev2+bzvRtUbehVd5IyAmTvLsgE/jlhPUIJV2POSAK+bKOV+ZWEp9qMOj1hq8A==",
+      "version": "2.83.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.83.1.tgz",
+      "integrity": "sha512-hM2fsHl2TXk3B0MTq7zRU/KqJiVrnTQ3SXbAfleQCfCf/Jpy6yD6nGqrEADFAYNLSPoA9iC3SLnO73SPqqjjRQ==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.79.1.tgz",
-      "integrity": "sha512-iOPT9hbpP7z9otAzAgSr3HksjZe/QQXdyE7P1A4EESAzmLktOGfzzHydJqU1wfE9BbgK4ioCS0dJ3EaCCtWGpg==",
+      "version": "2.83.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.83.1.tgz",
+      "integrity": "sha512-bFYXJDRyuH9x/xmANucKiEzzAbF683XDKOEmSivEgIkGP3zYkZ6beWajSAOQqRsm1VOPjgcpFuJtggUOkdPVKg==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.165",
+        "@aws-cdk/asset-awscli-v1": "^2.2.177",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.139",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.1.1",
@@ -8156,7 +8265,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.5.0",
+        "semver": "^7.5.1",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -8293,7 +8402,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.5.0",
+          "version": "7.5.1",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -8531,9 +8640,9 @@
       }
     },
     "cdk-nag": {
-      "version": "2.27.8",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.27.8.tgz",
-      "integrity": "sha512-QTgMYFDv6PA+xL+8Mo6+KpxlgWdLNanhW7QZSNAmigmptY6wc72/+7ihHUiqv7pasNcatOdOlGkJ0bpHVHM0iw==",
+      "version": "2.27.37",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.27.37.tgz",
+      "integrity": "sha512-l/9gNyV1bA0OqdFatTsWFcccUlEsxYDblGfrqNyUw+nvAH5f4y5l6wxhvmH7jkQ8w6XriXKeBFkuc0Gl1/YAVw==",
       "requires": {}
     },
     "chalk": {
@@ -8650,9 +8759,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.2.24",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.24.tgz",
-      "integrity": "sha512-35U5rfqCm800L98WwAgsig3jfy0ACOenjEh3o9t95kXvpGqviQO28HyERm9hCgtGVT8xZzczPNAZoVWkDbntzg=="
+      "version": "10.2.52",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.52.tgz",
+      "integrity": "sha512-+agHle0qck/Z2ARWtI8WpAiFzBFweti2ai03ShK3R708WTmny+HO97joPQ99oQQvmHaAgCZmAqEUufeySk9J0Q=="
     },
     "convert-source-map": {
       "version": "2.0.0",
@@ -8830,9 +8939,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
-      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -10168,7 +10277,6 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -10177,7 +10285,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -10185,8 +10292,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -10468,9 +10574,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -13,26 +13,26 @@
     "e2e": "node ./node_modules/@cucumber/cucumber/bin/cucumber-js e2e/features/*.feature --require-module ts-node/register --require e2e/step-definitions/calculations.ts"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.115",
-    "@types/jest": "^29.5.1",
-    "@types/node": "^18.15.11",
-    "@types/prettier": "2.7.2",
-    "aws-cdk": "^2.79.1",
+    "@types/aws-lambda": "^8.10.117",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.3.1",
+    "@types/prettier": "^2.7.3",
+    "aws-cdk": "^2.83.1",
     "@cucumber/cucumber": "^9.1.2",
     "expect": "^29.5.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.79.1-alpha.0",
-    "@aws-sdk/client-cognito-identity-provider": "^3.332.0",
-    "@aws-sdk/client-secrets-manager": "^3.332.0",
-    "aws-cdk-lib": "^2.79.1",
+    "@aws-cdk/aws-apigatewayv2-authorizers-alpha": "^2.83.1-alpha.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.352.0",
+    "@aws-sdk/client-secrets-manager": "^3.352.0",
+    "aws-cdk-lib": "^2.83.1",
     "axios": "^1.4.0",
-    "cdk-nag": "^2.27.8",
-    "constructs": "^10.2.24",
+    "cdk-nag": "^2.27.37",
+    "constructs": "^10.2.52",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
Resolving the following:

```
# npm audit report

fast-xml-parser  <4.2.4
Severity: high
fast-xml-parser vulnerable to Regex Injection via Doctype Entities - https://github.com/advisories/GHSA-6w63-h3fj-q4vw
fix available via `npm audit fix`
node_modules/fast-xml-parser
  @aws-sdk/client-sts  <=3.54.1 || 3.55.0 - 3.186.1 || 3.188.0 - 3.335.0 || 3.337.0 - 3.347.0
  Depends on vulnerable versions of fast-xml-parser
  node_modules/@aws-sdk/client-sts
    @aws-sdk/client-cognito-identity-provider  3.12.0 - 3.54.1 || 3.55.0 - 3.347.0
    Depends on vulnerable versions of @aws-sdk/client-sts
    node_modules/@aws-sdk/client-cognito-identity-provider
    @aws-sdk/client-secrets-manager  3.12.0 - 3.347.0
    Depends on vulnerable versions of @aws-sdk/client-sts
    node_modules/@aws-sdk/client-secrets-manager

4 high severity vulnerabilities
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.